### PR TITLE
SDL3 Support

### DIFF
--- a/dear-imgui.cabal
+++ b/dear-imgui.cabal
@@ -88,15 +88,23 @@ flag vulkan
 
 flag sdl
   description:
-    Enable SDL backend.
+    Enable SDL2 backend.
   default:
     True
   manual:
     True
 
+flag sdl3
+  description:
+    Enable SDL3 backend.
+  default:
+    False
+  manual:
+    True
+
 flag sdl-renderer
   description:
-    Enable SDL Renderer backend (requires the SDL_RenderGeometry function available in SDL 2.0.18+).
+    Enable SDL2 Renderer backend (requires the SDL_RenderGeometry function available in SDL 2.0.18+).
     The sdl configuration flag must also be enabled when using this flag.
   default:
     False
@@ -277,6 +285,25 @@ library
         DearImGui.SDL.Renderer
       cxx-sources:
         imgui/backends/imgui_impl_sdlrenderer2.cpp
+
+  if flag(sdl3)
+    exposed-modules:
+      DearImGui.SDL3
+    build-depends:
+      sdl3
+    cxx-sources:
+      imgui/backends/imgui_impl_sdl3.cpp
+
+    if os(windows) || os(darwin)
+      extra-libraries:
+        SDL3
+    else
+      pkgconfig-depends:
+        sdl3
+
+    if flag(vulkan)
+      exposed-modules:
+        DearImGui.SDL3.Vulkan
 
   if flag(glfw)
     exposed-modules:

--- a/src/DearImGui/SDL3.hs
+++ b/src/DearImGui/SDL3.hs
@@ -41,8 +41,8 @@ import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Cpp as Cpp
 
 -- sdl3
-import SDL
-import SDL.Events
+import SDL3
+import SDL3.Events
 
 -- transformers
 import Control.Monad.IO.Class

--- a/src/DearImGui/SDL3.hs
+++ b/src/DearImGui/SDL3.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+Module: DearImGui.SDL3
+
+SDL3 specific functions backend for Dear ImGui.
+
+Modules for initialising a backend with SDL3 can be found under the corresponding backend,
+e.g. "DearImGui.SDL3.Vulkan".
+-}
+
+module DearImGui.SDL3 (
+    -- ** SDL3
+    sdl3NewFrame
+  , sdl3Shutdown
+  , pollEventWithImGui
+  , pollEventsWithImGui
+    -- *** Raw
+  , dispatchRawEvent
+  )
+  where
+
+-- base
+import Control.Monad
+  ( void, when )
+import Foreign.Marshal.Alloc
+  ( alloca )
+import Foreign.Ptr
+  ( Ptr, castPtr )
+
+-- inline-c
+import qualified Language.C.Inline as C
+
+-- inline-c-cpp
+import qualified Language.C.Inline.Cpp as Cpp
+
+-- sdl3
+import SDL
+import SDL.Events
+
+-- transformers
+import Control.Monad.IO.Class
+  ( MonadIO, liftIO )
+
+
+C.context (Cpp.cppCtx <> C.bsCtx)
+C.include "imgui.h"
+C.include "backends/imgui_impl_sdl3.h"
+C.include "<SDL3/SDL.h>"
+Cpp.using "namespace ImGui"
+
+
+-- | Wraps @ImGui_ImplSDL3_NewFrame@.
+sdl3NewFrame :: MonadIO m => m ()
+sdl3NewFrame = liftIO do
+  [C.exp| void { ImGui_ImplSDL3_NewFrame(); } |]
+
+
+-- | Wraps @ImGui_ImplSDL3_Shutdown@.
+sdl3Shutdown :: MonadIO m => m ()
+sdl3Shutdown = liftIO do
+  [C.exp| void { ImGui_ImplSDL3_Shutdown(); } |]
+
+-- | Call the SDL3 'pollEvent' function, while also dispatching the event to
+-- Dear ImGui. You should use this in your application instead of 'pollEvent'.
+pollEventWithImGui :: MonadIO m => m (Maybe SDLEvent)
+pollEventWithImGui = liftIO do
+  alloca \evPtr -> do
+    sdlPumpEvents
+
+    -- We use NULL first to check if there's an event.
+    nEvents <- sdlPeepEventsRaw evPtr 1 SDL_PEEKEVENT SDL_EVENT_FIRST SDL_EVENT_LAST
+
+    when (nEvents > 0) do
+      void $ dispatchRawEvent evPtr
+
+    sdlPollEvent
+
+-- | Dispatch a raw 'Raw.Event' value to Dear ImGui.
+--
+-- You may want this function instead of 'pollEventWithImGui' if you do not use
+-- @sdl3@'s higher-level 'Event' type (e.g. your application has its own polling
+-- mechanism).
+--
+-- __It is your application's responsibility to both manage the input__
+-- __pointer's memory and to fill the memory location with a raw 'Raw.Event'__
+-- __value.__
+dispatchRawEvent :: MonadIO m => Ptr SDLEvent -> m Bool
+dispatchRawEvent evPtr = liftIO do
+  let evPtr' = castPtr evPtr :: Ptr ()
+  (0 /=) <$> [C.exp| bool { ImGui_ImplSDL3_ProcessEvent((const SDL_Event*) $(void* evPtr')) } |]
+
+-- | Like the SDL3 'pollEvents' function, while also dispatching the events to
+-- Dear ImGui. See 'pollEventWithImGui'.
+pollEventsWithImGui :: MonadIO m => m [SDLEvent]
+pollEventsWithImGui = do
+  e <- pollEventWithImGui
+  case e of
+    Nothing -> pure []
+    Just e' -> ( e' : ) <$> pollEventsWithImGui

--- a/src/DearImGui/SDL3/Vulkan.hs
+++ b/src/DearImGui/SDL3/Vulkan.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-|
+Module: DearImGui.SDL3.Vulkan
+
+Initialising the Vulkan backend for Dear ImGui using SDL3.
+-}
+
+module DearImGui.SDL3.Vulkan
+  ( sdl3InitForVulkan )
+  where
+
+-- inline-c
+import qualified Language.C.Inline as C
+
+-- inline-c-cpp
+import qualified Language.C.Inline.Cpp as Cpp
+
+-- sdl3
+import SDL.Video
+  ( SDLWindow(..) )
+
+-- transformers
+import Control.Monad.IO.Class ( MonadIO, liftIO )
+
+import Foreign (castPtr)
+
+
+C.context Cpp.cppCtx
+C.include "imgui.h"
+C.include "backends/imgui_impl_vulkan.h"
+C.include "backends/imgui_impl_sdl3.h"
+C.include "<SDL3/SDL.h>"
+C.include "<SDL3/SDL_vulkan.h>"
+Cpp.using "namespace ImGui"
+
+
+-- | Wraps @ImGui_ImplSDL3_InitForVulkan@.
+sdl3InitForVulkan :: MonadIO m => SDLWindow -> m Bool
+sdl3InitForVulkan (SDLWindow windowPtr) = liftIO do
+  let ptr = castPtr windowPtr
+  ( 0 /= ) <$> [C.exp| bool { ImGui_ImplSDL3_InitForVulkan((SDL_Window*)$(void* ptr)) } |]

--- a/src/DearImGui/SDL3/Vulkan.hs
+++ b/src/DearImGui/SDL3/Vulkan.hs
@@ -20,7 +20,7 @@ import qualified Language.C.Inline as C
 import qualified Language.C.Inline.Cpp as Cpp
 
 -- sdl3
-import SDL.Video
+import SDL3.Video
   ( SDLWindow(..) )
 
 -- transformers


### PR DESCRIPTION
This adds support for SDL3 (under the flag 'sdl3'), which default to 'False' as the sdl3-hs library is currently not yet on hackage. This PR should likely not be merged until then, but I am posting this now in case someone else has the same need.